### PR TITLE
fix(action.yml): cache-store input name didn't match references

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         # cache nix store https://github.com/cachix/install-nix-action/issues/56#issuecomment-1240991760
         - name: "Cache Nix store"
           uses: actions/cache@v3.0.11
-          if: ${{ inputs.cache-nix-store == 'true' }}
+          if: ${{ inputs.cache-store == 'true' }}
           id: nix-cache
           with:
               path: /tmp/nixcache
@@ -53,7 +53,7 @@ runs:
 
         - name: "Import Nix store cache"
           shell: bash
-          if: ${{ inputs.cache-nix-store == 'true' && steps.nix-cache.outputs.cache-hit == 'true' }}
+          if: ${{ inputs.cache-store == 'true' && steps.nix-cache.outputs.cache-hit == 'true' }}
           run: |
               echo "::group::Nix store import"
               nix-store --import < /tmp/nixcache
@@ -97,7 +97,7 @@ runs:
 
         - name: "Export Nix store cache"
           shell: bash
-          if: ${{ inputs.cache-nix-store == 'true' && steps.nix-cache.outputs.cache-hit != 'true' }}
+          if: ${{ inputs.cache-store == 'true' && steps.nix-cache.outputs.cache-hit != 'true' }}
           run: |
               echo "::group::Nix store export"
               nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nixcache


### PR DESCRIPTION
References within steps to `inputs.cache-nix-store` updated to match the input name `cache-store`.